### PR TITLE
Check HRESULT from FontFamily GetFont call

### DIFF
--- a/FontEnumeration/FontEnumerator.cpp
+++ b/FontEnumeration/FontEnumerator.cpp
@@ -172,10 +172,13 @@ Array<UINT32>^ FontEnumerator::ListSupportedChars(String^ fontName)
 		hr = pFontFamily->GetFont(0, &pFont);
 	}
 
-	BOOL hasChar;
-	for (UINT32 i = 0; i < 65535; i++) {
-		hr = pFont->HasCharacter(i, &hasChar);
-		charCodes[i] = hasChar ? i : 0;
+	if (SUCCEEDED(hr))
+	{
+		BOOL hasChar;
+		for (UINT32 i = 0; i < 65535; i++) {
+			hr = pFont->HasCharacter(i, &hasChar);
+			charCodes[i] = hasChar ? i : 0;
+		}
 	}
 	/*
 	DWRITE_UNICODE_RANGE range;


### PR DESCRIPTION
When IDWriteFontFamily1->GetFont fails, the IDWriteFont3 out parameter
comes back null. We should guard using it on whether GetFont was
successful.
