### PR TITLE
Fix incremental build

### DIFF
--- a/CharMap Plus/CharMap Plus.csproj
+++ b/CharMap Plus/CharMap Plus.csproj
@@ -100,7 +100,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Fonts\onlinefonts.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Fonts\MaterialDesignIcons.ttf">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -168,12 +168,10 @@
     <Page Include="Assets\AppStyles.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Page>
     <Page Include="Assets\AppTheme.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Page>
     <Page Include="Views\CharDetail.xaml">
       <SubType>Designer</SubType>


### PR DESCRIPTION
VS was doing a full rebuild each time it runs the app.  Tweaked places where files were set to "always copy" to output folder that caused code to recompile incorrectly.
